### PR TITLE
[ENGINE] Implement `FileManager`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ name = "engine"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "log",
  "tempfile",
  "thiserror",
  "tokio",
@@ -142,6 +143,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ members = [
 [workspace.dependencies]
 tokio = { version = "1.46.0", features = ["full"] }
 thiserror = "2"
+env_logger = "0.11.8"
+log = "0.4.27"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 tokio.workspace = true
 thiserror.workspace = true
 byteorder = "1.5.0"
+log.workspace = true
 
 [dev-dependencies]
 tempfile = "3.20.0"


### PR DESCRIPTION
## Done in this PR
After our talk I changed this part of our library to be fully sync - in the future we will have to have a talk about what we gonna do about it from higher lever perspective (`spawn_blocking` vs some thread pool).
I implemented all the functions that we currently support in `FileManager`. 
It should be noted that we have const `DEFAULT_NEXT_PAGE_ID` - I kinda just picked random value, after some tests we will have to pick a more suitable value.