### PR TITLE
[ENGINE] Rename `FileManager` and `DiskManager`

### DIFF
--- a/engine/src/disk_manager.rs
+++ b/engine/src/disk_manager.rs
@@ -1,19 +1,19 @@
-﻿use std::collections::HashMap;
-use std::path::{PathBuf};
-use crate::file_manager::{FileManager, FileManagerError};
+﻿use crate::paged_file::{PagedFile, PagedFileError};
 use directories::ProjectDirs;
+use std::collections::HashMap;
+use std::path::PathBuf;
 use thiserror::Error;
 
-/// Represents possible file types inside a table directory (refer to file_structure.md for more 
+/// Represents possible file types inside a table directory (refer to file_structure.md for more
 /// details)
-#[derive(Eq, PartialEq, Hash, Clone,Debug)]
-enum FileType{
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+enum FileType {
     Data,
     Index,
 }
 
 /// Helper type created to make referring to files easier and cleaner.
-#[derive(Eq, Hash, PartialEq,Clone,Debug)]
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
 pub struct FileKey {
     table_name: String,
     file_type: FileType,
@@ -39,36 +39,39 @@ impl FileKey {
     }
 }
 
-/// Responsible for storing and distributing ['FileManager']s of a single database 
+/// Responsible for storing and distributing [`PagedFile`]s of a single database
 /// to higher level components.
 ///
-/// As a singleton it allows the ['FileManager']s to persist beyond a single query and thus
+/// As a singleton it allows the [`PagedFile`]s to persist beyond a single query and thus
 /// eliminates the time needed to instantiate them each time.
-struct DiskManager {
-    open_files: HashMap<FileKey, FileManager>,
+pub struct DiskManager {
+    open_files: HashMap<FileKey, PagedFile>,
     base_path: PathBuf,
 }
 
-/// Error for ['DiscManager'] related operations
+/// Error for [`DiskManager`] related operations
 #[derive(Error, Debug)]
-pub enum DiscManagerError{
+pub enum DiscManagerError {
     #[error("couldn't find the data directory")]
     DirectoryNotFound,
-    #[error("file manager error: {0}")]
-    FileManagerError(#[from] FileManagerError),
+    #[error("paged file error: {0}")]
+    PagedFileError(#[from] PagedFileError),
 }
 
 impl DiskManager {
-    /// Creates a new DiscManager that handles files for a single database, whose name is passed to 
-    /// this function as an argument 
-    /// 
-    /// Can fail if the directory in which we want to store the data (refer to file_structure.md for 
+    /// Creates a new [`DiskManager`] that handles files for a single database, whose name is passed to
+    /// this function as an argument
+    ///
+    /// Can fail if the directory in which we want to store the data (refer to file_structure.md for
     /// OS-specific details) doesn't exist.
     pub fn new(database_name: &str) -> Result<Self, DiscManagerError> {
-        match ProjectDirs::from("", "", "CoDB"){
+        match ProjectDirs::from("", "", "CoDB") {
             None => Err(DiscManagerError::DirectoryNotFound),
             Some(project_dir) => {
-                let base_path = project_dir.data_local_dir().to_path_buf().join(database_name);
+                let base_path = project_dir
+                    .data_local_dir()
+                    .to_path_buf()
+                    .join(database_name);
                 Ok(DiskManager {
                     open_files: HashMap::new(),
                     base_path,
@@ -77,17 +80,23 @@ impl DiskManager {
         }
     }
 
-    /// Returns a file manager for a specific combination of table name and file type stored in 
-    /// FileKey or creates and stores it if one didn't exist beforehand. 
-    /// 
-    /// Can fail if file manager instantiation didn't succeed (refer to 
-    /// FileManager implementation file for more details)
-    pub fn get_or_open_new_file(&mut self, key: FileKey) -> Result<&mut FileManager, DiscManagerError> {
-        let file_path = self.base_path.join(&key.table_name);    
-        Ok(self.open_files.entry(key).or_insert(FileManager::new(file_path)?))
+    /// Returns a [`PagedFile`] for a specific combination of table name and file type stored in
+    /// FileKey or creates and stores it if one didn't exist beforehand.
+    ///
+    /// Can fail if [`PagedFile`] instantiation didn't succeed (refer to
+    /// [`PagedFile`]'s implementation for more details)
+    pub fn get_or_open_new_file(
+        &mut self,
+        key: FileKey,
+    ) -> Result<&mut PagedFile, DiscManagerError> {
+        let file_path = self.base_path.join(&key.table_name);
+        Ok(self
+            .open_files
+            .entry(key)
+            .or_insert(PagedFile::new(file_path)?))
     }
-    
-    /// Closes a file and removes its entry from the stored FileManagers. Can be used for when
+
+    /// Closes a file and removes its entry from the stored [`PagedFile`]s. Can be used for when
     /// a table is deleted or renamed.
     pub fn close_file(&mut self, key: &FileKey) {
         self.open_files.remove(key);

--- a/engine/src/files_manager.rs
+++ b/engine/src/files_manager.rs
@@ -1,10 +1,12 @@
-﻿use crate::paged_file::{PagedFile, PagedFileError};
+﻿//! FilesManager module — manages and distributes paged files in a single database.
+
+use crate::paged_file::{PagedFile, PagedFileError};
 use directories::ProjectDirs;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use thiserror::Error;
 
-/// Represents possible file types inside a table directory (refer to file_structure.md for more
+/// Represents possible file types inside a table directory (refer to `docs/file_structure.md` for more
 /// details)
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 enum FileType {
@@ -44,35 +46,35 @@ impl FileKey {
 ///
 /// As a singleton it allows the [`PagedFile`]s to persist beyond a single query and thus
 /// eliminates the time needed to instantiate them each time.
-pub struct DiskManager {
+pub struct FilesManager {
     open_files: HashMap<FileKey, PagedFile>,
     base_path: PathBuf,
 }
 
-/// Error for [`DiskManager`] related operations
+/// Error for [`FilesManager`] related operations
 #[derive(Error, Debug)]
-pub enum DiscManagerError {
+pub enum FilesManagerError {
     #[error("couldn't find the data directory")]
     DirectoryNotFound,
     #[error("paged file error: {0}")]
     PagedFileError(#[from] PagedFileError),
 }
 
-impl DiskManager {
-    /// Creates a new [`DiskManager`] that handles files for a single database, whose name is passed to
+impl FilesManager {
+    /// Creates a new [`FilesManager`] that handles files for a single database, whose name is passed to
     /// this function as an argument
     ///
-    /// Can fail if the directory in which we want to store the data (refer to file_structure.md for
+    /// Can fail if the directory in which we want to store the data (refer to `docs/file_structure.md` for
     /// OS-specific details) doesn't exist.
-    pub fn new(database_name: &str) -> Result<Self, DiscManagerError> {
+    pub fn new(database_name: &str) -> Result<Self, FilesManagerError> {
         match ProjectDirs::from("", "", "CoDB") {
-            None => Err(DiscManagerError::DirectoryNotFound),
+            None => Err(FilesManagerError::DirectoryNotFound),
             Some(project_dir) => {
                 let base_path = project_dir
                     .data_local_dir()
                     .to_path_buf()
                     .join(database_name);
-                Ok(DiskManager {
+                Ok(FilesManager {
                     open_files: HashMap::new(),
                     base_path,
                 })
@@ -88,7 +90,7 @@ impl DiskManager {
     pub fn get_or_open_new_file(
         &mut self,
         key: FileKey,
-    ) -> Result<&mut PagedFile, DiscManagerError> {
+    ) -> Result<&mut PagedFile, FilesManagerError> {
         let file_path = self.base_path.join(&key.table_name);
         Ok(self
             .open_files

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod catalog;
-pub mod file_manager;
 pub mod disk_manager;
+pub mod paged_file;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod catalog;
-pub mod disk_manager;
+pub mod files_manager;
 pub mod paged_file;
 
 pub fn add(left: u64, right: u64) -> u64 {

--- a/engine/src/paged_file.rs
+++ b/engine/src/paged_file.rs
@@ -1,4 +1,4 @@
-//! Disk module — abstraction layer for managing on-disk files and page operations.
+//! PagedFile module — abstraction layer for managing on-disk paged-files and page operations.
 
 use std::{
     collections::HashSet,


### PR DESCRIPTION
## Done in this PR

- renamed `FileManager` -> `PagedFile`
- renamed `DiskManager` -> `FilesManager`
- made minor comments fixes
