### PR TITLE
[ENGINE] Update file structure docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,120 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [     
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'client'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=client",
+                    "--package=client"
+                ],
+                "filter": {
+                    "name": "client",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'client'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=client",
+                    "--package=client"
+                ],
+                "filter": {
+                    "name": "client",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'engine'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=engine"
+                ],
+                "filter": {
+                    "name": "engine",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'query'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=query"
+                ],
+                "filter": {
+                    "name": "query",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'server'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=server",
+                    "--package=server"
+                ],
+                "filter": {
+                    "name": "server",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'server'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=server",
+                    "--package=server"
+                ],
+                "filter": {
+                    "name": "server",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/engine/docs/files_structure.md
+++ b/engine/docs/files_structure.md
@@ -1,16 +1,15 @@
 ## coDB files structure
 
-All coDB files are stored in a special directory named `.coDB`.  
-- On Linux, this is located at `~/.coDB`.
-- On Windows, it is located at `%APPDATA%\.coDB`.
+All coDB files are stored in a special directory:  
+- On Linux, this is located at `$HOME/.local/share/codb`.
+- On Windows, it is located at `C:\Users\$USER\AppData\Roaming\CoDB\data`.
 
 
 ### Structure
 
-At the top level inside the `.coDB` directory are subdirectories for each database. For example, `database-A` contains data for the database named "database-A":
+At the top level inside the directory there are subdirectories for each database. For example, `database-A` contains data for the database named "database-A":
 
 ```text
-.coDB
     /database-A
     /database-B
     /database-C
@@ -19,7 +18,6 @@ At the top level inside the `.coDB` directory are subdirectories for each databa
 Inside each database directory, there is a metadata file (`metadata.coDB`) and directories for each table:
 
 ```text
-.coDB
     /database-A
         metadata.coDB
         /table-A
@@ -32,7 +30,6 @@ Each table directory contains two files:
 - `table_name.tbl`: Stores table rows using slotted pages.
 
 ```text
-.coDB
     /database-A
         metadata.coDB
         /table-A
@@ -42,4 +39,4 @@ Each table directory contains two files:
 
 ### Assumptions
 
-Files used in coDB must match the exact layout described in this documentation. Any deviation can result in unexpected behaviour. Currently, changing the location of the `.coDB` directory is not supported, but this may change in the future.
+Files used in coDB must match the exact layout described in this documentation. Any deviation can result in unexpected behaviour. Currently, changing the location of the main coDB directory is not supported, but this may change in the future.


### PR DESCRIPTION
## Done in this PR

I updated the docs about file structure, now they should point to the actual location that we use in our implementation using [directories crate](https://crates.io/crates/directories)

I also added the `.vscode/launch.json` file - it's for debugging purposes only. I wasn't really sure if I should keep it in source control so let me know what you think - I can remove it if you think it's unnecessary.