### PR TITLE
[ENGINE] Implement Catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,8 @@ dependencies = [
  "byteorder",
  "directories",
  "log",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -154,6 +156,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -340,10 +348,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "server"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -9,6 +9,8 @@ thiserror.workspace = true
 byteorder = "1.5.0"
 directories = "6.0.0"
 log.workspace = true
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 /// is small enough that [`Catalog`] can be used as an in-memory data structure.
 #[derive(Debug)]
 pub struct Catalog {
-    /// Path to underlyng file
+    /// Path to underlying file
     file_path: PathBuf,
     /// Maps each table name to its metadata. Stores all tables from database.
     tables: HashMap<String, TableMetadata>,
@@ -97,11 +97,11 @@ impl Catalog {
         // Performance note: it's much easier to write whole json all at once instead of updating only the diff.
         // I'm aware that for a large number of tables and columns it might be quite slow,
         // though we assume this operation to be called quite rarely (we will mostly load the catalog
-        // but making upadates to it will be (at least we expect it to be) quite rare).
+        // but making updates to it will be (at least we expect it to be) quite rare).
         let catalog_json = CatalogJson::from(&*self);
         let content = serde_json::to_string_pretty(&catalog_json)?;
 
-        // We can unwrap here, because we know `UNIX_EPOCH` was before `SystemTimen::now`
+        // We can unwrap here, because we know `UNIX_EPOCH` was before `SystemTime::now`
         let epoch = time::SystemTime::now()
             .duration_since(time::UNIX_EPOCH)
             .unwrap()

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -966,7 +966,7 @@ mod tests {
 
         // then table `users` is returned
         assert!(result.is_ok());
-        assert_table(&users, &result.unwrap());
+        assert_table(&users, result.unwrap());
     }
 
     #[test]
@@ -982,7 +982,7 @@ mod tests {
         assert!(result.is_err());
         assert_catalog_error_variant(
             &result.unwrap_err(),
-            &&&CatalogError::TableNotFound("missing".into()),
+            &CatalogError::TableNotFound("missing".into()),
         );
     }
 
@@ -1033,7 +1033,7 @@ mod tests {
 
         // then Ok(()) is returned and table is removed
         assert!(result.is_ok());
-        assert!(c.tables.get("users").is_none());
+        assert!(!c.tables.contains_key("users"));
     }
 
     #[test]

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -35,10 +35,10 @@ pub enum CatalogError {
     #[error("table '{0}' already exists")]
     TableAlreadyExists(String),
     /// Underlying IO module returned error
-    #[error("io error occured: {0}")]
+    #[error("io error occurred: {0}")]
     IoError(#[from] io::Error),
     /// File contains invalid json
-    #[error("json error occured: {0}")]
+    #[error("json error occurred: {0}")]
     JsonError(#[from] serde_json::Error),
 }
 
@@ -108,7 +108,7 @@ impl Catalog {
             .as_millis();
         let tmp_path = self.file_path.with_extension(format!("tmp-{epoch}"));
 
-        // We firstly store content in temporary file, only when all content is successfuly saved to file
+        // We firstly store content in temporary file, only when all content is successfully saved to file
         // we swap it with previous file content.
         let mut tmp_file = OpenOptions::new()
             .write(true)
@@ -125,7 +125,7 @@ impl Catalog {
 
     /// Return the latest version of [`CatalogJson`] saved on disk.
     /// Most of the time it will just return content of `main_dir_path/database_name`,
-    /// but in cases when there was a problem during [`Catalog::sync_to_disk`] and new content was only saved to temprorary file it will return the content from newest temporary file.
+    /// but in cases when there was a problem during [`Catalog::sync_to_disk`] and new content was only saved to temporary file it will return the content from newest temporary file.
     /// Can fail if io error occurs or file was not properly formatted (JSON).
     fn latest_catalog_json<P>(
         main_dir_path: P,
@@ -164,19 +164,19 @@ impl Catalog {
             match tmp_is_latest {
                 true => {
                     let tmp_catalog_json = CatalogJson::read_from_file(&tmp_path);
-                    // In this case it means we have successfuly deserialize proper [`CatalogJson`] structure from the file.
+                    // In this case it means we have successfully deserialize proper [`CatalogJson`] structure from the file.
                     // We will assume that this is the most recent version that should be used.
                     if let Ok(cj) = tmp_catalog_json {
                         fs::rename(&tmp_path, &main_file)?;
                         catalog_json = Some(cj);
                         break;
                     }
-                    // In this case we tried to read from file but it didn't contait proper json structure.
+                    // In this case we tried to read from file but it didn't contain proper json structure.
                     // We can remove the file as it will no longer be needed.
                     fs::remove_file(&tmp_path)?;
                 }
                 false => {
-                    // If main file has latest modification time than we no longer need tmp file and can remove it.
+                    // If main file has latest modification time then we no longer need tmp file and can remove it.
                     fs::remove_file(&tmp_path)?;
                     catalog_json = Some(CatalogJson::read_from_file(&main_file)?);
                     break;
@@ -222,7 +222,7 @@ pub enum TableMetadataError {
     /// While creating [`TableMetadata`] there were more than one column with the same name in `columns`
     #[error("column '{0}' was defined more than once")]
     DuplicatedColumn(String),
-    /// While creating [`TableMetadata`] `primary_key_column_name` was set to column which names does not appear in `columns`
+    /// While creating [`TableMetadata`] `primary_key_column_name` was set to column which name does not appear in `columns`
     #[error("unknown primary key column: {0}")]
     UnknownPrimaryKeyColumn(String),
     /// Column with provided name does not exist in `columns`
@@ -231,14 +231,14 @@ pub enum TableMetadataError {
     /// Column with provided names already exists in `columns`
     #[error("column '{0}' already exists")]
     ColumnAlreadyExists(String),
-    /// Invalid columns was used for operation, e.g. tried to remove primary key column
+    /// Invalid column was used for operation, e.g. tried to remove primary key column
     #[error("column '{0}' cannot be used in that context")]
     InvalidColumnUsed(String),
 }
 
 impl TableMetadata {
     /// Creates new [`TableMetadata`].
-    /// Can fail if columns slice contains more than one column with the same name or `primary_key_column_name` is not in `columns`.
+    /// Can fail if the columns slice contains more than one column with the same name, or if `primary_key_column_name` is not in `columns`.
     pub fn new(
         name: impl Into<String>,
         columns: &[ColumnMetadata],
@@ -310,7 +310,7 @@ impl TableMetadata {
         match idx {
             Some(idx) => {
                 self.columns.swap_remove(idx);
-                // Removed last element - don't need to update any index
+                // Removed last element - no need to update any index
                 if idx == self.columns.len() {
                     return Ok(());
                 }
@@ -484,7 +484,7 @@ impl From<TableJson> for TableMetadata {
             .into_iter()
             .map(ColumnMetadata::from)
             .collect();
-        // We can unwrap here as we our sure that table saved to file is well-defined table.
+        // We can unwrap here as we are sure that table saved to file is well-defined.
         TableMetadata::new(value.name, &columns, value.primary_key_column_name).unwrap()
     }
 }

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -359,7 +359,7 @@ impl From<&Catalog> for CatalogJson {
 struct TableJson {
     name: String,
     columns: Vec<ColumnJson>,
-    primary_key_columns_name: String,
+    primary_key_column_name: String,
 }
 
 impl From<&TableMetadata> for TableJson {
@@ -367,7 +367,7 @@ impl From<&TableMetadata> for TableJson {
         TableJson {
             name: value.name.clone(),
             columns: value.columns.iter().map(ColumnJson::from).collect(),
-            primary_key_columns_name: value.primary_key_column_name.clone(),
+            primary_key_column_name: value.primary_key_column_name.clone(),
         }
     }
 }
@@ -380,7 +380,7 @@ impl From<TableJson> for TableMetadata {
             .map(ColumnMetadata::from)
             .collect();
         // We can unwrap here as we our sure that table saved to file is well-defined table.
-        TableMetadata::new(value.name, &columns, value.primary_key_columns_name).unwrap()
+        TableMetadata::new(value.name, &columns, value.primary_key_column_name).unwrap()
     }
 }
 
@@ -584,7 +584,7 @@ mod tests {
                     { "name": "id", "ty": "I32", "pos": 0, "base_offset": 0, "base_offset_pos": 0 },
                     { "name": "name", "ty": "String", "pos": 1, "base_offset": 4, "base_offset_pos": 1 }
                 ],
-                "primary_key_columns_name": "id"
+                "primary_key_column_name": "id"
             },
             {
                 "name": "posts",
@@ -592,7 +592,7 @@ mod tests {
                     { "name": "id", "ty": "I32", "pos": 0, "base_offset": 0, "base_offset_pos": 0 },
                     { "name": "title", "ty": "String", "pos": 1, "base_offset": 4, "base_offset_pos": 1 }
                 ],
-                "primary_key_columns_name": "id"
+                "primary_key_column_name": "id"
             },
             {
                 "name": "comments",
@@ -600,7 +600,7 @@ mod tests {
                     { "name": "id", "ty": "I32", "pos": 0, "base_offset": 0, "base_offset_pos": 0 },
                     { "name": "body", "ty": "String", "pos": 1, "base_offset": 4, "base_offset_pos": 1 }
                 ],
-                "primary_key_columns_name": "id"
+                "primary_key_column_name": "id"
             }
         ]
     }
@@ -725,7 +725,7 @@ mod tests {
         assert_eq!(loaded.tables.len(), 1);
         assert_eq!(loaded.tables[0].name, "users");
         assert_eq!(loaded.tables[0].columns.len(), 2);
-        assert_eq!(loaded.tables[0].primary_key_columns_name, "id");
+        assert_eq!(loaded.tables[0].primary_key_column_name, "id");
     }
 
     #[test]

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -129,7 +129,7 @@ impl Catalog {
         Ok(())
     }
 
-    /// Return the latest version of [`CatalogJson`] saved on disk.
+    /// Returns the latest version of [`CatalogJson`] saved on disk.
     /// Most of the time it will just return content of `main_dir_path/database_name`,
     /// but in cases when there was a problem during [`Catalog::sync_to_disk`] and new content was only saved to temporary file it will return the content from newest temporary file.
     /// Can fail if io error occurs or file was not properly formatted (JSON).

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -61,7 +61,7 @@ impl Catalog {
     }
 
     /// Returns table with `table_name` name.
-    /// Returns `None` if table with `table_name` name does not exist.
+    /// Can fail if table with `table_name` name does not exist.
     pub fn table(&self, table_name: &str) -> Result<&TableMetadata, CatalogError> {
         self.tables
             .get(table_name)
@@ -414,4 +414,10 @@ impl From<ColumnJson> for ColumnMetadata {
             base_offset_pos: value.base_offset_pos,
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
 }

--- a/engine/src/paged_file.rs
+++ b/engine/src/paged_file.rs
@@ -44,13 +44,7 @@ pub enum PagedFileError {
     InvalidFileFormat(&'static str),
     /// Underlying IO module returned error
     #[error("io error occured: {0}")]
-    IoError(#[source] io::Error),
-}
-
-impl From<io::Error> for PagedFileError {
-    fn from(err: io::Error) -> Self {
-        PagedFileError::IoError(err)
-    }
+    IoError(#[from] io::Error),
 }
 
 impl PagedFile {


### PR DESCRIPTION
## Done in the PR

I implemented functionality defined in `catalog` module following the docs created earlier. 
As we discussed, currently json is used for on-disk representation - may be in the future it will need to be changed, but for now it should be fine. 