### PR TITLE
[QUERY] Add DDL support to Parser

### DIFF
--- a/query/docs/grammar.md
+++ b/query/docs/grammar.md
@@ -182,7 +182,7 @@ Precedence (from lowest to highest)
  <alter_action> :: <add_alter_action> | <rename_alter_action> | <drop_alter_action>
  <add_alter_action> :: ADD <column_name> <type>
  <rename_alter_action> :: RENAME <rename_target>
- <rename_target> :: COLUMN <column_name> TO <column_name> | TABLE <table_name> TO <table_name>
+ <rename_target> :: COLUMN <column_name> TO <column_name> | TABLE TO <table_name>
  <drop_alter_action> :: DROP COLUMN <column_name>
 ```
 

--- a/query/src/ast.rs
+++ b/query/src/ast.rs
@@ -108,12 +108,13 @@ pub struct CreateStatement {
 pub struct CreateColumnDescriptor {
     pub name: NodeId,
     pub ty: Type,
-    pub addon: Option<CreateColumnAddon>,
+    pub addon: CreateColumnAddon,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CreateColumnAddon {
     PrimaryKey,
+    None,
 }
 
 #[derive(Debug)]

--- a/query/src/ast.rs
+++ b/query/src/ast.rs
@@ -126,7 +126,8 @@ pub struct AlterStatement {
 #[derive(Debug)]
 pub enum AlterAction {
     Add(AddAlterAction),
-    Rename(RenameAlterAction),
+    RenameColumn(RenameColumnAlterAction),
+    RenameTable(RenameTableAlterAction),
     Drop(DropAlterAction),
 }
 
@@ -137,16 +138,14 @@ pub struct AddAlterAction {
 }
 
 #[derive(Debug)]
-pub struct RenameAlterAction {
+pub struct RenameColumnAlterAction {
     pub previous_name: NodeId,
     pub new_name: NodeId,
-    pub ty: RenameType,
 }
 
 #[derive(Debug)]
-pub enum RenameType {
-    Table,
-    Column,
+pub struct RenameTableAlterAction {
+    pub new_name: NodeId,
 }
 
 #[derive(Debug)]

--- a/query/src/parser.rs
+++ b/query/src/parser.rs
@@ -720,9 +720,14 @@ impl Parser {
         let table_name = self.parse_table_name()?;
         Ok(Statement::Truncate(TruncateStatement { table_name }))
     }
-
+    /// Parses a DROP statement.
+    ///
+    /// Syntax:
+    /// `DROP TABLE <table>`
     fn parse_drop_statement(&mut self) -> Result<Statement, ParserError> {
-        todo!()
+        self.expect_token(TokenType::Table)?;
+        let table_name = self.parse_table_name()?;
+        Ok(Statement::Drop(DropStatement { table_name }))
     }
 
     /// Advances the parser by one token.
@@ -1397,6 +1402,25 @@ mod tests {
             panic!(
                 "Expected Identifier for table, got {:#?}",
                 ast.node(trunc_stmt.table_name)
+            );
+        };
+        assert_eq!(table_ident.value, "sessions");
+    }
+
+    #[test]
+    fn parses_drop_statement_correctly() {
+        let parser = Parser::new("DROP TABLE sessions;");
+        let ast = parser.parse_program().unwrap();
+        assert_eq!(ast.statements.len(), 1);
+
+        let Statement::Drop(drop_stmt) = &ast.statements[0] else {
+            panic!("Expected Drop statement, got {:#?}", ast.statements[0]);
+        };
+
+        let Expression::Identifier(table_ident) = ast.node(drop_stmt.table_name) else {
+            panic!(
+                "Expected Identifier for table, got {:#?}",
+                ast.node(drop_stmt.table_name)
             );
         };
         assert_eq!(table_ident.value, "sessions");


### PR DESCRIPTION
## In this PR:
- added DDL support to Paser
- small refactor in alter table rename table action -> removed duplicated table name
- changed representation of empty addon -> instead of using `Option<CreateColumnAddon>` added `CreateColumnAddon::None`