### PR TITLE
[QUERY] Add table aliases to grammar

### DIFF
--- a/query/docs/grammar.md
+++ b/query/docs/grammar.md
@@ -40,7 +40,7 @@ CoSQL includes a set of essential data types suitable for building production-gr
 
 - SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, RENAME, DROP
 - INT32, INT64, FLOAT32, FLOAT64, BOOL, STRING, DATE, DATETIME
-- WHERE, FROM, INTO, SET, VALUES
+- WHERE, FROM, INTO, SET, VALUES, AS
 - TABLE, COLUMN, PRIMARY_KEY
 - TRUE, FALSE
 
@@ -115,8 +115,10 @@ Precedence (from lowest to highest)
 ### Database specifics
 
 ```
- <column_name> :: <identifier>
- <table_name> :: <identifier>
+ <column_name> :: <identifier> <column_alias>
+ <column_alias> :: '.' <identifier> | ε
+ <table_name> :: <identifier> <table_alias>
+ <table_alias> :: AS <identifier> | ε
  <value> :: <literal> | <expression>
  <type> :: INT32 | INT64 | FLOAT32 | FLOAT64 | BOOL | STRING | DATE | DATETIME
 ```


### PR DESCRIPTION
Added table aliases to grammar, now grammar allows query like `SELECT * FROM users AS u;`.

I made it pretty generic and didn't create different `table_name` rule for select statement - as the result now grammr also allows to do something like `DELETE FROM users AS u WHERE u.id > 100`. IMO we can leave it like that, though it will probably only make sense to use aliases in select queries with joins.