### PR TITLE
Update rust version and readme

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Rust 1.90
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.90.0
+        components: rustfmt, clippy
+        override: true
     - name: Check formatting
       run: cargo fmt --all -- --check
     - name: Run clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 resolver = "3"
 members = ["client", "engine", "metadata", "query", "server"]
 
+[workspace.package]
+rust-version = "1.90.0"
+
 [workspace.dependencies]
 tokio = { version = "1.46.0", features = ["full"] }
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The project is organized as a Cargo workspace with multiple crates for modularit
     cargo new <LIBRARY_NAME> --vsc none --lib
     ```
 
-Ensure the root `Cargo.toml` includes the new crate under `[workspace].members`. Add it manually if needed.
+Ensure the root `Cargo.toml` includes the new crate under `[workspace].members` and `new-crate/Cargo.toml` includes `rust-version.workspace = true` under `package`. Add those manually if needed.
+
 
 ### Adding internal dependency
 
@@ -64,7 +65,7 @@ external-common.workspace = true
 
 ### Prerequisites
 
-To build and run this project, you need Rust installed (version 1.88 or higher). You can install it from [https://rust-lang.org](https://rust-lang.org) or via `rustup`.
+To build and run this project, you need Rust installed. You can install it from [https://rust-lang.org](https://rust-lang.org) or via `rustup`.
 
 ### Running binaries
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ coDB is a relational database built from scratch.
     - [Adding a new crate](#adding-a-new-crate)
     - [Adding internal dependency](#adding-internal-dependency)
     - [Adding external dependecy](#adding-external-dependecy)
+    - [Updating rust version](#updating-rust-version)
 - [Running locally](#running-locally)
     - [Prerequisites](#prerequisites)
     - [Running binaries](#running-binaries)
@@ -60,6 +61,12 @@ Then in `query/Cargo.toml` and `engine/Cargo.toml`:
 [dependencies]
 external-common.workspace = true 
 ```
+
+### Updating rust version
+
+To update rust version you should update:
+- `rust_version` field in root `Cargo.toml`
+- `Set up Rust 1.X` step in github actions (`github/workflows/build_and_test.yaml`)
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,23 @@ crateB = { path = "../crateB" }
 
 ### Adding external dependecy
 
-TODO: figure out whether to do it in root Cargo.toml or do it in each crate separately. When decision is made update this paragraph.
+If an external crate is needed by only one coDB crate, add it to that crate's Cargo.toml.  
+For example, to add `external-1` to the `query` crate, add it in `query/Cargo.toml`.
+
+If an external crate is used by multiple workspace crates, add it to the root `Cargo.toml` under `[workspace.dependencies]` and reference it from each crate with `workspace = true`.  
+For example, add `external-common` to the root `Cargo.toml`:
+
+```toml
+[workspace.dependencies]
+external-common = "x.y"
+```
+
+Then in `query/Cargo.toml` and `engine/Cargo.toml`:
+
+```toml
+[dependencies]
+external-common.workspace = true 
+```
 
 ## Running locally
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,5 +2,6 @@
 name = "client"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "engine"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 metadata = { path = "../metadata" }

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -2,6 +2,7 @@
 name = "metadata"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -2,6 +2,7 @@
 name = "query"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 metadata = { path = "../metadata" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "server"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
-engine ={ path = "../engine" }
+engine = { path = "../engine" }


### PR DESCRIPTION
Now we enforce rust version via `Cargo.toml`.

I also updated the part in readme about adding external crates as we already figured it out.