### PR TITLE
Change slotted page api and add basic B-Tree nodes with search functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "bytemuck"
@@ -139,13 +142,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "bytemuck",
  "byteorder",
  "dashmap",
@@ -175,7 +179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,6 +20,7 @@ directories = "6.0.0"
 dashmap = "6.1.0"
 lru = "0.16.0"
 bytemuck = { version = "1.23.2", features = ["derive"] }
+bitflags = { version = "2.9.4", features = ["bytemuck"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/engine/src/b_tree.rs
+++ b/engine/src/b_tree.rs
@@ -2,7 +2,7 @@
 use crate::data_types::{DbSerializable, DbSerializationError};
 use crate::paged_file::PageId;
 use crate::slotted_page::{
-    ReprC, SlottedPage, SlottedPageBaseHeader, SlottedPageError, SlottedPageHeader,
+    ReprC, SlotId, SlottedPage, SlottedPageBaseHeader, SlottedPageError, SlottedPageHeader,
 };
 use bytemuck::{Pod, Zeroable};
 use std::cmp::{Ordering, PartialEq};
@@ -37,7 +37,7 @@ pub(crate) enum SearchResult {
     Found { record_ptr: RecordPointer },
 
     /// Leaf node: key not found, but insertion point identified
-    NotFoundLeaf { insert_slot_id: u16 },
+    NotFoundLeaf { insert_slot_id: SlotId },
 
     /// Internal node: follow this child
     FollowChild { child_ptr: PageId },
@@ -47,7 +47,7 @@ pub(crate) enum SearchResult {
 /// leaf nodes of the b-tree.
 pub(crate) struct RecordPointer {
     page_id: PageId,
-    slot_id: u16,
+    slot_id: SlotId,
 }
 
 impl DbSerializable for RecordPointer {
@@ -58,7 +58,7 @@ impl DbSerializable for RecordPointer {
 
     fn deserialize(buffer: &[u8]) -> Result<(Self, &[u8]), DbSerializationError> {
         let (page_id, rest) = PageId::deserialize(buffer)?;
-        let (slot_id, rest) = u16::deserialize(rest)?;
+        let (slot_id, rest) = SlotId::deserialize(rest)?;
         let record_ptr = Self { page_id, slot_id };
         Ok((record_ptr, rest))
     }
@@ -79,10 +79,6 @@ impl BTreePageHeader {
 
     pub fn is_leaf(&self) -> bool {
         self.page_type() == PageType::Leaf
-    }
-
-    pub fn is_internal(&self) -> bool {
-        self.page_type() == PageType::Internal
     }
 }
 
@@ -162,13 +158,13 @@ impl<Page: PageRead, Key: BTreeKey> BTreeNode<Page, Key> {
         Ok(SearchResult::FollowChild { child_ptr })
     }
 
-    fn get_key(&self, slot_id: u16) -> Result<Key, BTreeError> {
+    fn get_key(&self, slot_id: SlotId) -> Result<Key, BTreeError> {
         let record_bytes = self.slotted_page.read_record(slot_id)?;
         let (key, _) = Key::deserialize(record_bytes)?;
         Ok(key)
     }
 
-    fn get_child_ptr(&self, slot_id: u16) -> Result<PageId, BTreeError> {
+    fn get_child_ptr(&self, slot_id: SlotId) -> Result<PageId, BTreeError> {
         let record_bytes = self.slotted_page.read_record(slot_id)?;
         let (_, child_ptr_bytes) = Key::deserialize(record_bytes)?;
         let (child_ptr, _) = PageId::deserialize(child_ptr_bytes)?;

--- a/engine/src/b_tree.rs
+++ b/engine/src/b_tree.rs
@@ -1,0 +1,209 @@
+﻿use crate::cache::PageRead;
+use crate::data_types::{DbSerializable, DbSerializationError};
+use crate::paged_file::PageId;
+use crate::slotted_page::{
+    ReprC, SlottedPage, SlottedPageBaseHeader, SlottedPageError, SlottedPageHeader,
+};
+use bytemuck::{Pod, Zeroable};
+use std::cmp::{Ordering, PartialEq};
+use std::marker::PhantomData;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub(crate) enum BTreeError {
+    #[error("internal error from slotted page occurred: {0}")]
+    SlottedPageInternalError(#[from] SlottedPageError),
+    #[error("error occurred while deserializing: {0}")]
+    DeserializationError(#[from] DbSerializationError),
+    #[error("corrupt B-tree node detected: {reason}")]
+    CorruptNode { reason: String },
+}
+#[repr(C)]
+#[derive(Pod, Zeroable, Copy, Clone)]
+pub(crate) struct BTreePageHeader {
+    base_header: SlottedPageBaseHeader,
+    page_type: u16,
+    leftmost_child_pointer: PageId,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum PageType {
+    Leaf,
+    Internal,
+}
+
+pub(crate) enum SearchResult {
+    /// Leaf node: exact match found
+    Found { record_ptr: RecordPointer },
+
+    /// Leaf node: key not found, but insertion point identified
+    NotFoundLeaf { insert_slot_id: u16 },
+
+    /// Internal node: follow this child
+    FollowChild { child_ptr: PageId },
+}
+
+/// A struct containing all the information necessary to get the actual record data. Stored inside
+/// leaf nodes of the b-tree.
+pub(crate) struct RecordPointer {
+    page_id: PageId,
+    slot_id: u16,
+}
+
+impl DbSerializable for RecordPointer {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        buf.extend(self.page_id.to_le_bytes());
+        buf.extend(self.slot_id.to_le_bytes());
+    }
+
+    fn deserialize(buffer: &[u8]) -> Result<(Self, &[u8]), DbSerializationError> {
+        let (page_id, rest) = PageId::deserialize(buffer)?;
+        let (slot_id, rest) = u16::deserialize(rest)?;
+        let record_ptr = Self { page_id, slot_id };
+        Ok((record_ptr, rest))
+    }
+}
+pub(crate) trait BTreeKey: DbSerializable + Ord + Clone {}
+
+impl BTreePageHeader {
+    const LEAF_PAGE: u16 = 0;
+    const INTERNAL_PAGE: u16 = 1;
+
+    fn page_type(&self) -> PageType {
+        match self.page_type {
+            Self::LEAF_PAGE => PageType::Leaf,
+            Self::INTERNAL_PAGE => PageType::Internal,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        self.page_type() == PageType::Leaf
+    }
+
+    pub fn is_internal(&self) -> bool {
+        self.page_type() == PageType::Internal
+    }
+}
+
+unsafe impl ReprC for BTreePageHeader {}
+impl SlottedPageHeader for BTreePageHeader {
+    fn base(&self) -> &SlottedPageBaseHeader {
+        &self.base_header
+    }
+}
+pub(crate) struct BTreeNode<Page, Key>
+where
+    Key: BTreeKey,
+{
+    slotted_page: SlottedPage<Page>,
+    _key_marker: PhantomData<Key>,
+}
+
+impl<Page: PageRead, Key: BTreeKey> BTreeNode<Page, Key> {
+    pub fn new(page: Page) -> Self {
+        Self {
+            slotted_page: SlottedPage::new(page, true),
+            _key_marker: PhantomData,
+        }
+    }
+
+    fn get_btree_header(&self) -> Result<&BTreePageHeader, BTreeError> {
+        Ok(self.slotted_page.get_header::<BTreePageHeader>()?)
+    }
+
+    fn get_base_header(&self) -> Result<&SlottedPageBaseHeader, BTreeError> {
+        Ok(self.get_btree_header()?.base())
+    }
+    pub fn search(&self, target_key: &Key) -> Result<SearchResult, BTreeError> {
+        if self.is_leaf()? {
+            self.search_leaf(target_key)
+        } else {
+            self.search_internal(target_key)
+        }
+    }
+
+    fn search_internal(&self, target_key: &Key) -> Result<SearchResult, BTreeError> {
+        let num_slots = self.slotted_page.num_slots()?;
+
+        if num_slots == 0 {
+            return Ok(SearchResult::NotFoundLeaf { insert_slot_id: 0 });
+        }
+
+        let mut left = 0;
+        let mut right = num_slots - 1;
+
+        while left <= right {
+            let mid = (left + right) / 2;
+            let record_bytes = self.slotted_page.read_record(mid)?;
+            let (key, child_page_id_bytes) = Key::deserialize(record_bytes)?;
+
+            match key.cmp(target_key) {
+                Ordering::Less => {
+                    left = mid + 1;
+                }
+                Ordering::Equal => {
+                    let (child_page_id, _) = PageId::deserialize(child_page_id_bytes)?;
+                    return Ok(SearchResult::FollowChild {
+                        child_ptr: child_page_id,
+                    });
+                }
+                Ordering::Greater => {
+                    right = mid - 1;
+                }
+            }
+        }
+
+        let child_ptr = if left == 0 {
+            self.get_btree_header()?.leftmost_child_pointer
+        } else {
+            self.get_child_ptr(left - 1)?
+        };
+        Ok(SearchResult::FollowChild { child_ptr })
+    }
+
+    fn get_key(&self, slot_id: u16) -> Result<Key, BTreeError> {
+        let record_bytes = self.slotted_page.read_record(slot_id)?;
+        let (key, _) = Key::deserialize(record_bytes)?;
+        Ok(key)
+    }
+
+    fn get_child_ptr(&self, slot_id: u16) -> Result<PageId, BTreeError> {
+        let record_bytes = self.slotted_page.read_record(slot_id)?;
+        let (_, child_ptr_bytes) = Key::deserialize(record_bytes)?;
+        let (child_ptr, _) = PageId::deserialize(child_ptr_bytes)?;
+        Ok(child_ptr)
+    }
+
+    fn search_leaf(&self, target_key: &Key) -> Result<SearchResult, BTreeError> {
+        let mut left = 0;
+        let mut right = self.slotted_page.num_slots()? - 1;
+
+        while left <= right {
+            let mid = (left + right) / 2;
+            let record_bytes = self.slotted_page.read_record(mid)?;
+            let (key, child_page_id_bytes) = Key::deserialize(record_bytes)?;
+
+            match key.cmp(target_key) {
+                Ordering::Less => {
+                    left = mid + 1;
+                }
+                Ordering::Equal => {
+                    let (record_ptr, _) = RecordPointer::deserialize(child_page_id_bytes)?;
+                    return Ok(SearchResult::Found { record_ptr });
+                }
+                Ordering::Greater => {
+                    right = mid - 1;
+                }
+            }
+        }
+
+        Ok(SearchResult::NotFoundLeaf {
+            insert_slot_id: left,
+        })
+    }
+
+    fn is_leaf(&self) -> Result<bool, BTreeError> {
+        Ok(self.get_btree_header()?.is_leaf())
+    }
+}

--- a/engine/src/data_types.rs
+++ b/engine/src/data_types.rs
@@ -18,7 +18,7 @@ macro_rules! impl_db_serializable_for {
     };
 }
 
-impl_db_serializable_for!(i32, i64, u16, u32, f32, f64);
+impl_db_serializable_for!(i32, i64, u16, u32, u64, f32, f64);
 
 /// A trait for types that can be serialized to and deserialized from bytes
 /// for database storage.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,3 +1,4 @@
+mod b_tree;
 pub mod background_worker;
 pub mod cache;
 mod data_types;

--- a/engine/src/paged_file.rs
+++ b/engine/src/paged_file.rs
@@ -30,7 +30,7 @@ trait WritePageId: io::Write {
 impl<T> WritePageId for T where T: io::Write {}
 
 /// Size of each page in [`PagedFile`].
-const PAGE_SIZE: usize = 4096; // 4 kB
+pub(crate) const PAGE_SIZE: usize = 4096; // 4 kB
 
 /// Type representing page, should be used instead of bare array of bytes.
 pub type Page = [u8; PAGE_SIZE];


### PR DESCRIPTION
Slotted page changes:
- Make it generic over header type
- Use SlotId type alias for u16
- Add initialization methods + check for unitialized pages 
- Add flags to the header
- Remove read_valid_record method and move it to read_record, so there is no function for reading invalid records anymore