### PR TITLE
[WAL] Fix applying operations to pages that were deleted

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -4995,4 +4995,99 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_wal_redo_with_page_reallocation() {
+        // Test scenario: Insert records, truncate table (deallocates pages),
+        // then insert new record that reuses a previously allocated page ID.
+        // On restart, WAL redo should only apply the new record, not old ones.
+
+        let (catalog, temp_dir) = create_catalog();
+        let db_path = temp_dir.path().join("test_db");
+
+        {
+            // Create table, insert records, truncate, then insert one new record
+            let (executor, mut workers) = Executor::with_background_workers(&db_path, catalog)
+                .expect("with_background_workers should succeed");
+
+            // Create table
+            execute_single(
+                &executor,
+                "CREATE TABLE items (id INT32 PRIMARY_KEY, name STRING);",
+            );
+
+            // Insert initial records
+            execute_single(
+                &executor,
+                "INSERT INTO items (id, name) VALUES (1, 'Item One');",
+            );
+            execute_single(
+                &executor,
+                "INSERT INTO items (id, name) VALUES (2, 'Item Two');",
+            );
+            execute_single(
+                &executor,
+                "INSERT INTO items (id, name) VALUES (3, 'Item Three');",
+            );
+            execute_single(
+                &executor,
+                "INSERT INTO items (id, name) VALUES (4, 'Item Four');",
+            );
+
+            // Force WAL flush to ensure records are logged
+            thread::sleep(time::Duration::from_millis(150));
+
+            // Truncate table - deallocates all pages
+            execute_single(&executor, "TRUNCATE TABLE items;");
+
+            // Force WAL flush
+            thread::sleep(time::Duration::from_millis(150));
+
+            // Insert ONE new record - this might reuse a previously allocated page ID
+            execute_single(
+                &executor,
+                "INSERT INTO items (id, name) VALUES (1, 'Item One');",
+            );
+
+            // Force WAL flush to log the new insert
+            thread::sleep(time::Duration::from_millis(150));
+
+            // Shutdown cleanly
+            for mut handle in workers.drain(..) {
+                handle.shutdown().expect("shutdown should succeed");
+                handle.join().expect("join should succeed");
+            }
+        }
+
+        {
+            // Restart and verify WAL redo only applies the new record
+            // NOT the old 4 records that existed before truncate
+            let catalog = Catalog::new(temp_dir.path(), "test_db").unwrap();
+            let (executor, mut workers) = Executor::with_background_workers(&db_path, catalog)
+                .expect("Recovery should handle page reallocation correctly");
+
+            // Verify table has exactly 1 record (the one inserted after truncate)
+            let result = execute_single(&executor, "SELECT * FROM items;");
+            let (_, rows) = expect_select_successful(result);
+            assert_eq!(
+                rows.len(),
+                1,
+                "Expected 1 record after recovery, not the old 4 records"
+            );
+
+            // Verify it's the correct record
+            let record = &rows[0];
+            let id_value = &record.fields[0];
+            let name_value = &record.fields[1];
+
+            assert_eq!(id_value.as_i32().unwrap(), 1);
+            assert_eq!(name_value.as_string().unwrap(), "Item One");
+
+            // Cleanup
+            for mut handle in workers.drain(..) {
+                handle.shutdown().expect("shutdown should succeed");
+                handle.join().expect("join should succeed");
+            }
+        }
+    }
 }

--- a/storage/src/cache.rs
+++ b/storage/src/cache.rs
@@ -15,12 +15,15 @@ use std::{
 };
 use thiserror::Error;
 
-use crate::write_ahead_log::{SinglePageOperation, WalClient, WalHandle, WalRecordData};
 use crate::{
     background_worker::{BackgroundWorker, BackgroundWorkerHandle},
     files_manager::{FileKey, FilesManager, FilesManagerError},
     page_diff::PageDiff,
     paged_file::{Lsn, Page, PageId, PagedFile, PagedFileError, get_page_lsn, set_page_lsn},
+};
+use crate::{
+    paged_file::PAGE_SIZE,
+    write_ahead_log::{SinglePageOperation, WalClient, WalHandle, WalRecordData},
 };
 use types::serialization::DbSerializable;
 
@@ -448,12 +451,36 @@ impl Cache {
     /// In case if lock is not needed the return value should not be assigned, so that lock lives as little as needed.
     pub fn allocate_page(&self, file: &FileKey) -> Result<(PinnedWritePage, PageId), CacheError> {
         let pf = self.files.get_or_open_new_file(file)?;
-        let page_id = pf.lock().allocate_page()?;
+        let mut lock = pf.lock();
+
+        // Allocate new page
+        let page_id = lock.allocate_page()?;
         let id = FilePageRef {
             file_key: file.clone(),
             page_id,
         };
-        Ok((self.pin_write(&id)?, page_id))
+
+        // Initialize frame and add it to frames
+        let page = lock.read_page(page_id)?;
+        let new_frame = Arc::new(PageFrame::new(id.clone(), page));
+        self.frames.insert(id.clone(), new_frame.clone());
+        self.push_to_lru(&id);
+        drop(lock);
+
+        // Cleanup cache if too many frames in memory
+        if self.frames.len() > self.capacity && !self.try_evict_frame()? {
+            warn!("Cache: cannot evict frame - every frame in cache is pinned or lru is empty.");
+        }
+
+        // Manually mark whole page as diff - this way if during redo we have a case:
+        // - make changes to page
+        // - remove page
+        // - allocates page
+        // the newly allocated page will discard previous changes applied from wal.
+        let mut pinned_write_page = self.pin_write(&id)?;
+        pinned_write_page.mark_diff(0, PAGE_SIZE as _);
+
+        Ok((pinned_write_page, page_id))
     }
 
     /// Remove page from file.


### PR DESCRIPTION
- Added a couple of wal tests to `executor/lib.rs`
- Now when we allocate page in cache we mark it's all content as changed
- When we're redoing logs from wal at cache startup we skip pages that were deleted.